### PR TITLE
Fix for dataset with no jet features

### DIFF
--- a/jetnet/datasets/jetnet.py
+++ b/jetnet/datasets/jetnet.py
@@ -394,4 +394,4 @@ class JetNet(torch.utils.data.Dataset):
         return len(self.data)
 
     def __getitem__(self, idx):
-        return self.data[idx], self.jet_features[idx] if self.use_jet_features else self.data[idx]
+        return (self.data[idx], self.jet_features[idx]) if self.use_jet_features else self.data[idx]


### PR DESCRIPTION
- Currently if `use_jet_features = False`, it will return two copies of `self.data[idx], self.data[idx]`
- This PR makes it so it will only return one (I think)